### PR TITLE
Updated for NYT version of Wordle

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Wordle"
 uuid = "c88c3f80-0ab4-4432-9bb5-8d3b9443166e"
 authors = ["Jonathan Chen <jwhc@ucla.edu>"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 Crayons = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ Do you love Wordle? Do you live in the Julia REPL? Well now you can play Wordle 
 
 ## What is Wordle?
 
-[Wordle](https://www.powerlanguage.co.uk/wordle/) is a daily word guessing game where the objective is to guess the daily, five-letter "wordle" within six guesses. Each time you make a guess, you are given the following feedback:
+[Wordle](https://www.nytimes.com/games/wordle/index.html) is a daily word guessing game where the objective is to guess the daily, five-letter "wordle" within six guesses. Each time you make a guess, you are given the following feedback:
 - Letters that are in the correct position will be highlighted in green;
 - Letters that are in the wordle but not in the correct position are highlighted in yellow;
 - And, the rest are highlighted in gray.
 
-Here are the instructions from the [game](https://www.powerlanguage.co.uk/wordle/):
+Here are the instructions from the [game](https://www.nytimes.com/games/wordle/index.html):
 ![instructions-screenshot](https://images.squarespace-cdn.com/content/v1/50eca855e4b0939ae8bb12d9/80a523b2-edff-41ac-8a9e-d515285a0b74/How+to+play+original+Wordle.png?format=1000w)
 
 The game went viral as friends would compete with each other to see who could guess the wordle with the fewest number of guesses.

--- a/src/Wordle.jl
+++ b/src/Wordle.jl
@@ -13,7 +13,7 @@ available_letters, print_available_letters
 
 
 const CORRECT, PRESENT, INCORRECT, UNGUESSED = :🟩, :🟨, :⬛️, :⬜
-const WORDLE_URL = "https://www.powerlanguage.co.uk/wordle/"
+const WORDLE_URL = "https://www.nytimes.com/games/wordle"
 const WORDLE_START_DATE = Date(2021, 6, 19)
 
 

--- a/src/fetch.jl
+++ b/src/fetch.jl
@@ -15,9 +15,9 @@ wordles, valid_words = download_word_lists()
 """
 function download_word_lists()
     js_url = let
-        html = HTTP.request(:GET, WORDLE_URL).body |> String
+        html = HTTP.request(:GET, joinpath(WORDLE_URL, "index.html")).body |> String
 
-        filename = match(r"src=\"(main.\w+.js)\"", html) |> only
+        filename = match(r"src=\"(main.\w+.js)\"", html)[1]
         joinpath(WORDLE_URL, filename)
     end
 

--- a/src/fetch.jl
+++ b/src/fetch.jl
@@ -15,10 +15,10 @@ wordles, valid_words = download_word_lists()
 """
 function download_word_lists()
     js_url = let
-        html = HTTP.request(:GET, joinpath(WORDLE_URL, "index.html")).body |> String
+        html = HTTP.request(:GET, join((WORDLE_URL, "index.html"), '/')).body |> String
 
         filename = match(r"src=\"(main.\w+.js)\"", html)[1]
-        joinpath(WORDLE_URL, filename)
+        join((WORDLE_URL, filename), '/')
     end
 
     js = replace(HTTP.request(:GET, js_url).body |> String, "\n" => "")

--- a/test/Data.toml
+++ b/test/Data.toml
@@ -1,6 +1,6 @@
-wordle = 231
-version = "0.1.0"
+wordle = 241
+version = "0.1.1"
 
 [data]
-valid-words = "cbb6637f9250d224b9ced11a6b56ff1a36ad727e4e4616c7f4db7227b921be50"
-known-wordles = "3d99d459730c220673da9c2f4b4ddc136c26001a11d5721f53a746d2c77ceaf4"
+valid-words = "042ca970ca228693345b30c28329e3e29ab1e95b6afaebe71e1980cf9f52549f"
+known-wordles = "8071bd5baf74c705ae7b2fa2a53c0c626dae677cd4cd2109ebad70e6b66e4f2e"


### PR DESCRIPTION
The previous site powerlanguage.co.uk is now redirecting the [New York Times-hosted](https://www.nytimes.com/games/wordle/index.html) version. The NYT has also changed the word lists a bit (see [this tweet](https://twitter.com/MikeySlezak/status/1493344574260924420?s=20&t=sa5WD9GoGUyQ75GlHb2H8A)). Unfortunately, I did not save the original word lists (though intentionally) so this project will have no knowledge of them. They can be found on other Wordle repos if required.